### PR TITLE
Add SSL support

### DIFF
--- a/src/network/socketClass.ts
+++ b/src/network/socketClass.ts
@@ -2,12 +2,14 @@ import { EventEmitter } from "https://deno.land/std@0.110.0/node/events.ts";
 import { Buffer } from "https://deno.land/std@0.110.0/node/buffer.ts";
 import { iter } from "https://deno.land/std@0.110.0/io/util.ts";
 
+interface SslOptions {
+  certFile: string;
+}
+
 export class CustomSocket extends EventEmitter {
   conn?: Deno.Conn;
   isOpen = false;
-  //TODO - options should be typed as Deno.ConnectOptions, but need to refactor ssl
-  //deno-lint-ignore no-explicit-any
-  options: any;
+  options: Deno.ConnectOptions & { ssl?: SslOptions };
 
   constructor(options?: any) {
     super();
@@ -15,7 +17,7 @@ export class CustomSocket extends EventEmitter {
       hostname: options?.hostname || "localhost",
       port: options?.port || 9899,
       transport: options?.transport || "tcp",
-      ssl: options?.ssl || null,
+      ssl: options?.ssl,
     };
   }
 

--- a/src/network/socketClass.ts
+++ b/src/network/socketClass.ts
@@ -1,41 +1,41 @@
-import { KafkaJSNotImplemented } from '../errors.ts'
 import { EventEmitter } from "https://deno.land/std@0.110.0/node/events.ts";
 import { Buffer } from "https://deno.land/std@0.110.0/node/buffer.ts";
-import { iter } from 'https://deno.land/std@0.110.0/io/util.ts'
+import { iter } from "https://deno.land/std@0.110.0/io/util.ts";
 
 export class CustomSocket extends EventEmitter {
   conn?: Deno.Conn;
   isOpen = false;
   //TODO - options should be typed as Deno.ConnectOptions, but need to refactor ssl
   //deno-lint-ignore no-explicit-any
-  options: any
+  options: any;
 
   constructor(options?: any) {
     super();
     this.options = {
-      hostname: options?.hostname || 'localhost',
+      hostname: options?.hostname || "localhost",
       port: options?.port || 9899,
       transport: options?.transport || "tcp",
-      ssl: options?.ssl || null
+      ssl: options?.ssl || null,
     };
   }
 
-  
   async connect() {
     if (this.options.ssl) {
-      //Note: SSL functionality is currently not implemented correctly! Uncomment below to attempt.
-      throw new KafkaJSNotImplemented('SSL functionality is currently not implemented');
-      // const newOptions = {hostname: this.options.hostName, port: this.options.port, certFile: this.options.ssl.certFile}
-      // const conn = await Deno.connectTls(newOptions)
-      // this.open(conn)
+      const newOptions = {
+        hostname: this.options.hostname,
+        port: this.options.port,
+        certFile: this.options.ssl.certFile,
+      };
+      const conn = await Deno.connectTls(newOptions);
+      this.open(conn);
     } else {
       const conn = await Deno.connect(this.options);
-      this.open(conn)
+      this.open(conn);
     }
   }
 
   close() {
-    this.emit('close', this);
+    this.emit("close", this);
     this.conn?.close();
   }
 
@@ -43,21 +43,21 @@ export class CustomSocket extends EventEmitter {
     try {
       this.isOpen = true;
       this.conn = conn;
-      this.emit('connect', this);
-      
+      this.emit("connect", this);
+
       for await (const buffer of iter(conn)) {
-        this.emit('data', buffer)
+        this.emit("data", buffer);
       }
       this.close();
     } catch (e) {
-      this.emit('error', this, e);
+      this.emit("error", this, e);
       this.close();
     }
   }
 
   async write(data: Buffer): Promise<number> {
     const write = await this.conn?.write(data);
-   
-	  return Promise.resolve(<number>write)
+
+    return Promise.resolve(<number> write);
   }
 }

--- a/src/protocol/requests/apiVersions/v2/response.ts
+++ b/src/protocol/requests/apiVersions/v2/response.ts
@@ -1,6 +1,6 @@
 /** @format */
 
-import response from '../v1/response.ts';
+import responseV1 from "../v1/response.ts";
 
 /**
  * Starting in version 2, on quota violation, brokers send out responses before throttling.
@@ -14,8 +14,7 @@ import response from '../v1/response.ts';
  *     max_version => INT16
  *   throttle_time_ms => INT32
  */
-const { parse }: any = response.parse;
-const decodeV1: any = response.decode;
+const { parse, decode: decodeV1 } = responseV1;
 const decode = async (rawData: any) => {
   const decoded = await decodeV1(rawData);
 

--- a/src/protocol/requests/saslAuthenticate/v1/response.ts
+++ b/src/protocol/requests/saslAuthenticate/v1/response.ts
@@ -1,9 +1,8 @@
-import {Decoder} from '../../../decoder.ts'
-import {Encoder} from '../../../encoder.ts'
-import response from '../v0/response.ts'
-import { failIfVersionNotSupported } from '../../../error.ts'
+import { Decoder } from "../../../decoder.ts";
+import { Encoder } from "../../../encoder.ts";
+import responseV0 from "../v0/response.ts";
+import { failIfVersionNotSupported } from "../../../error.ts";
 
-const parseV0 = response.parse;
 /**
  * SaslAuthenticate Response (Version: 1) => error_code error_message sasl_auth_bytes
  *   error_code => INT16
@@ -13,27 +12,27 @@ const parseV0 = response.parse;
  */
 //deno-lint-ignore require-await
 const decode = async (rawData: any) => {
-  const decoder = new Decoder(rawData)
-  const errorCode = decoder.readInt16()
+  const decoder = new Decoder(rawData);
+  const errorCode = decoder.readInt16();
 
-  failIfVersionNotSupported(errorCode)
-  const errorMessage = decoder.readString()
+  failIfVersionNotSupported(errorCode);
+  const errorMessage = decoder.readString();
 
   // This is necessary to make the response compatible with the original
   // mechanism protocols. They expect a byte response, which starts with
   // the size
-  const authBytesEncoder = new Encoder().writeBytes(decoder.readBytes())
-  const authBytes = authBytesEncoder.buffer
-  const sessionLifetimeMs = decoder.readInt64().toString()
+  const authBytesEncoder = new Encoder().writeBytes(decoder.readBytes());
+  const authBytes = authBytesEncoder.buffer;
+  const sessionLifetimeMs = decoder.readInt64().toString();
 
   return {
     errorCode,
     errorMessage,
     authBytes,
     sessionLifetimeMs,
-  }
-}
-export default{
+  };
+};
+export default {
   decode,
-  parseV0,
-}
+  parse: responseV0.parse,
+};


### PR DESCRIPTION
Adds SSL support. Tested this locally successfully, by connecting to a private SSL Kafka cluster. Would like to setup a test scenario through docker-compose, but not sure how yet.

Closes #3 