### PR TITLE
[NEEDS REVIEW] Fix BadResource on broker timeout

### DIFF
--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -363,7 +363,11 @@ export default class Connection {
             requestTimeout,
             sendRequest: async () => {
               this.logger.demo(`Sending request to broker...${requestInfo(request)}`)
-              await this.socket.write(requestPayload.buffer)
+              try {
+                await this.socket.write(requestPayload.buffer)
+              } catch (e) {
+                reject(e)
+              }
             },
           });
         } catch (e) {

--- a/src/network/socketClass.ts
+++ b/src/network/socketClass.ts
@@ -58,8 +58,17 @@ export class CustomSocket extends EventEmitter {
   }
 
   async write(data: Buffer): Promise<number> {
-    const write = await this.conn?.write(data);
+    let write = 0;
+    try {
+      write = await this.conn?.write(data) || 0;
+    } catch (e) {
+      this.conn = undefined
+      this.isOpen = false
+      this.emit("error", this, e)
+      this.emit("close", this)
+      console.error("The broker has closed the connection - reconnecting")
+    }
 
-    return Promise.resolve(<number> write);
+    return write;
   }
 }


### PR DESCRIPTION
I have done some limited testing on this PR - it no longer crashes and data seems to arrive when producing. 

Not sure if this is the best approach? Also, am emitting `close` as well as `error`. Seems to work but not sure both are necessary.


Fix/workaround for #11:

* Explicity reject exceptions in `connect.ts` ("uncaught promise")
* Emit `error` and `close` in `socketClass.ts` ("BadResource")
